### PR TITLE
fix: don't let namespace modify kubeconfig's current context

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 GitHub Action to report info and logs from the current namespace.
 
 ## Optional input parameters
-- `namespace`: Updates the kubeconfig's current context's namespace to this
-  namespace.
+- `namespace`: Emit a report for another namespace than the kubeconfig's current
+  context.
 - `important-workloads`: Always provide logs of these workloads. Use space a
   separator, example: `deploy/my-deployment sts/my-statefulset`.
 

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
   # Manually keep the descriptions synced with the readme!
   namespace:
     default: ""
-    description: "Updates the kubeconfig's current context's namespace to this namespace."
+    description: "Emit a report for another namespace than the kubeconfig's current context."
     required: false
   important-workloads:
     default: ""
@@ -32,16 +32,10 @@ runs:
       run: |
         exit 0
 
-    - name: Update current namespace
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.namespace }}" ]; then
-            sudo --preserve-env kubectl config set-context --current --namespace="${{ inputs.namespace }}" > /dev/null
-        fi
-
     - name: Emit namespace report
       shell: bash
       env:
         REPORT_IMPORTANT_WORKLOADS: ${{ inputs.important-workloads }}
+        NAMESPACE: ${{ inputs.namespace }}
       run: |
         ${{ github.action_path }}/k8s-namespace-report

--- a/k8s-namespace-report
+++ b/k8s-namespace-report
@@ -35,6 +35,11 @@ export f_h3_ok="\n\033[${green};1m%s\033[0m\n"
 export f_h2_err="\n\033[${red};1m%s\n\033[${red};1m${divider}\033[0m\n"
 export f_h3_err="\n\033[${red};1m%s\033[0m\n"
 
+# We compactify the passing of --namespace, and by using --namespace= we can
+# ensure even a blank string will result in the correct behavior without
+# erroring, which is to use the current contexts namespace.
+export ns=--namespace=${NAMESPACE}
+
 printf "$f_h1_ok" "# Full namespace report"
 
 # Provide a resource overview
@@ -42,13 +47,13 @@ printf "$f_h1_ok" "# Full namespace report"
 printf "\n\n"
 printf "$f_h2_ok" "## Resource overview"
 printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset,pod"
-kubectl get deploy,sts,ds,pod
+kubectl get deploy,sts,ds,pod ${ns}
 printf "$f_h3_ok" "### \$ kubectl get secret,configmap"
-kubectl get secret,cm
+kubectl get secret,cm ${ns}
 printf "$f_h3_ok" "### \$ kubectl get service,ingress,networkpolicy"
-kubectl get svc,ing,netpol
+kubectl get svc,ing,netpol ${ns}
 printf "$f_h3_ok" "### \$ kubectl get serviceaccount,role,rolebinding"
-kubectl get sa,role,rolebinding
+kubectl get sa,role,rolebinding ${ns}
 
 
 # Check if any container of any pod has a restartCount > 0. Then, we inspect
@@ -61,7 +66,7 @@ kubectl get sa,role,rolebinding
 #       ref: https://github.com/kubernetes/kubernetes/issues/97530
 #
 PODS_RESTARTED=$(
-    kubectl get pods -o json \
+    kubectl get pods -o json ${ns} \
         | jq -r '
             .items[]
             | select(
@@ -79,9 +84,9 @@ if [ -n "$PODS_RESTARTED" ]; then
 
     for var in $PODS_RESTARTED; do
         printf "$f_h3_err" "### \$ kubectl describe pod/$var"
-        kubectl describe pod/$var
+        kubectl describe pod/$var ${ns}
         printf "$f_h3_err" "### \$ kubectl logs --previous --all-containers --follow --ignore-errors pod/$var"
-        kubectl logs --previous --all-containers --follow --ignore-errors pod/$var || echo  # a newline on failure for consistency
+        kubectl logs --previous --all-containers --follow --ignore-errors pod/$var ${ns} || echo  # a newline on failure for consistency
     done
 fi
 
@@ -89,7 +94,7 @@ fi
 # Check if any pods are pending
 #
 PODS_PENDING=$(
-    kubectl get pods -o json \
+    kubectl get pods -o json ${ns} \
         | jq -r '
             .items[]
             | select(.status.phase == "Pending")
@@ -103,7 +108,7 @@ if [ -n "$PODS_PENDING" ]; then
 
     for var in $PODS_PENDING; do
         printf "$f_h3_err" "### \$ kubectl describe pod/$var"
-        kubectl describe pod/$var
+        kubectl describe pod/$var ${ns}
     done
 fi
 
@@ -111,7 +116,7 @@ fi
 # Check if any pod has a container with a non-ready status
 #
 PODS_NON_READY=$(
-    kubectl get pods -o json \
+    kubectl get pods -o json ${ns} \
         | jq -r '
             .items[]
             | select(
@@ -129,9 +134,9 @@ if [ -n "$PODS_NON_READY" ]; then
 
     for var in $PODS_NON_READY; do
         printf "$f_h3_err" "### \$ kubectl describe pod/$var"
-        kubectl describe pod/$var
+        kubectl describe pod/$var ${ns}
         printf "$f_h3_err" "### \$ kubectl logs --all-containers pod/$var"
-        kubectl logs --all-containers pod/$var || echo  # a newline on failure for consistency
+        kubectl logs --all-containers pod/$var ${ns} || echo  # a newline on failure for consistency
     done
 
 fi
@@ -146,6 +151,6 @@ if [ -n "$REPORT_IMPORTANT_WORKLOADS" ]; then
 
     for var in $REPORT_IMPORTANT_WORKLOADS; do
         printf "$f_h3_ok" "### \$ kubectl logs --all-containers $var"
-        kubectl logs --all-containers $var || echo  # a newline on failure for consistency
+        kubectl logs --all-containers $var ${ns} || echo  # a newline on failure for consistency
     done
 fi


### PR DESCRIPTION
Closes #3

I consider this a breaking bugfix even though it was the documented behavior, it was simply too weird default behavior. Due to that, I think it makes more sense to bump this within v1 than to go to v2 as that forces users to bump a major version to get the bugfix they probably just want straight up, unless they relied on the weird behavior intentionally.

> [...] I was surprised by the comment that `jupyterhub/action-k8s-namespace-report` changes the kubeconfig namespace.