### PR TITLE
Add pod-selector input to limit reporting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
           - k3s-channel: v1.20
             test-pods: restarted healthy non-ready pending
             input-namespace: ""
+            input-pod-selector: pod-number notin (2,3)
             input-important-workloads: pod/test-healthy-1 pod/test-healthy-2
           - k3s-channel: v1.20
             test-pods: ""
@@ -93,6 +94,7 @@ jobs:
         id: k8s-namespace-report
         with:
           namespace: ${{ matrix.input-namespace }}
+          pod-selector: ${{ matrix.input-pod-selector }}
           important-workloads: ${{ matrix.input-important-workloads }}
 
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,13 +38,13 @@ jobs:
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
           - k3s-channel: v1.20
-            test-namespace: ""
             test-pods: restarted healthy non-ready pending
-            test-important-workloads: pod/test-healthy-1 pod/test-healthy-2
+            input-namespace: ""
+            input-important-workloads: pod/test-healthy-1 pod/test-healthy-2
           - k3s-channel: v1.20
-            test-namespace: kube-system
             test-pods: ""
-            test-important-workloads: ""
+            input-namespace: kube-system
+            input-important-workloads: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -92,8 +92,8 @@ jobs:
         uses: ./
         id: k8s-namespace-report
         with:
-          namespace: ${{ matrix.test-namespace }}
-          important-workloads: ${{ matrix.test-important-workloads }}
+          namespace: ${{ matrix.input-namespace }}
+          important-workloads: ${{ matrix.input-important-workloads }}
 
 
       # - name: Validate local action's set outputs/envs

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ GitHub Action to report info and logs from the current namespace.
 ## Optional input parameters
 - `namespace`: Emit a report for another namespace than the kubeconfig's current
   context.
+- `pod-selector`: Limit pod reporting to pods with certain labels, example:
+  `app.kubernetes.io/component notin (logger,metrics)`.
 - `important-workloads`: Always provide logs of these workloads. Use space a
   separator, example: `deploy/my-deployment sts/my-statefulset`.
 
@@ -35,6 +37,7 @@ jobs:
         if: always()
         # with:
         #   namespace: my-namespace
+        #   pod-selector: app.kubernetes.io/component notin (logger,metrics)
         #   important-workloads: deploy/my-deployment sts/my-statefulset
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub Action to report info and logs from the current namespace.
 - `namespace`: Emit a report for another namespace than the kubeconfig's current
   context.
 - `pod-selector`: Limit pod reporting to pods with certain labels, example:
-  `app.kubernetes.io/component notin (logger,metrics)`.
+  `app.kubernetes.io/component notin (secret-server,boring-server)`.
 - `important-workloads`: Always provide logs of these workloads. Use space a
   separator, example: `deploy/my-deployment sts/my-statefulset`.
 
@@ -37,7 +37,7 @@ jobs:
         if: always()
         # with:
         #   namespace: my-namespace
-        #   pod-selector: app.kubernetes.io/component notin (logger,metrics)
+        #   pod-selector: app.kubernetes.io/component notin (secret-server,boring-server)
         #   important-workloads: deploy/my-deployment sts/my-statefulset
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,22 +1,19 @@
 # Reference: https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/metadata-syntax-for-github-actions
 ---
 name: Kubernetes namespace report
+# Manually keep the action, input, and output descriptions in sync with the
+# readme!
 description: |
-  Emits a report of the current k8s cluster and the current namespace.
-
-branding:
-  icon: server
-  color: purple
+  GitHub Action to report info and logs from the current namespace.
 
 inputs:
-  # Manually keep the descriptions synced with the readme!
   namespace:
     default: ""
     description: "Emit a report for another namespace than the kubeconfig's current context."
     required: false
   pod-selector:
     default: ""
-    description: "Limit pod reporting to pods with certain labels, example: `app.kubernetes.io/component notin (logger,metrics)`."
+    description: "Limit pod reporting to pods with certain labels, example: `app.kubernetes.io/component notin (secret-server,boring-server)`. "
     required: false
   important-workloads:
     default: ""
@@ -27,6 +24,10 @@ inputs:
 #   my-output:
 #     description: "..."
 #     value: "..."
+
+branding:
+  icon: server
+  color: purple
 
 runs:
   using: "composite"

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,10 @@ inputs:
     default: ""
     description: "Emit a report for another namespace than the kubeconfig's current context."
     required: false
+  pod-selector:
+    default: ""
+    description: "Limit pod reporting to pods with certain labels, example: `app.kubernetes.io/component notin (logger,metrics)`."
+    required: false
   important-workloads:
     default: ""
     description: "Always provide logs of these workloads. Use space a separator, example: `deploy/my-deployment sts/my-statefulset`."
@@ -37,5 +41,6 @@ runs:
       env:
         REPORT_IMPORTANT_WORKLOADS: ${{ inputs.important-workloads }}
         NAMESPACE: ${{ inputs.namespace }}
+        POD_SELECTOR: ${{ inputs.pod-selector }}
       run: |
         ${{ github.action_path }}/k8s-namespace-report

--- a/ci/healthy-pod.yaml
+++ b/ci/healthy-pod.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test-healthy-1
+  labels:
+    pod-number: "1"
 spec:
   containers:
     - name: busybox
@@ -18,6 +20,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test-healthy-2
+  labels:
+    pod-number: "2"
 spec:
   containers:
     - name: busybox

--- a/ci/pending-pod.yaml
+++ b/ci/pending-pod.yaml
@@ -2,7 +2,23 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-pending
+  name: test-pending-1
+  labels:
+    pod-number: "1"
+spec:
+  # nodeSelector to ensure this pod never becomes scheduled
+  nodeSelector:
+    test.jupyter.org/node: no-node-has-this-label
+  containers:
+    - name: busybox
+      image: busybox
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pending-2
+  labels:
+    pod-number: "2"
 spec:
   # nodeSelector to ensure this pod never becomes scheduled
   nodeSelector:

--- a/k8s-namespace-report
+++ b/k8s-namespace-report
@@ -38,7 +38,8 @@ export f_h3_err="\n\033[${red};1m%s\033[0m\n"
 # We compactify the passing of --namespace, and by using --namespace= we can
 # ensure even a blank string will result in the correct behavior without
 # erroring, which is to use the current contexts namespace.
-export ns=--namespace=${NAMESPACE}
+export ns="--namespace=${NAMESPACE}"
+export psel="--selector=${POD_SELECTOR}"
 
 printf "$f_h1_ok" "# Full namespace report"
 
@@ -46,8 +47,10 @@ printf "$f_h1_ok" "# Full namespace report"
 #
 printf "\n\n"
 printf "$f_h2_ok" "## Resource overview"
-printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset,pod"
-kubectl get deploy,sts,ds,pod ${ns}
+printf "$f_h3_ok" "### \$ kubectl get deployment,statefulset,daemonset"
+kubectl get deploy,sts,ds ${ns}
+printf "$f_h3_ok" "### \$ kubectl get pod"
+kubectl get pod ${ns} "${psel}"
 printf "$f_h3_ok" "### \$ kubectl get secret,configmap"
 kubectl get secret,cm ${ns}
 printf "$f_h3_ok" "### \$ kubectl get service,ingress,networkpolicy"
@@ -66,7 +69,7 @@ kubectl get sa,role,rolebinding ${ns}
 #       ref: https://github.com/kubernetes/kubernetes/issues/97530
 #
 PODS_RESTARTED=$(
-    kubectl get pods -o json ${ns} \
+    kubectl get pods -o json ${ns} "${psel}" \
         | jq -r '
             .items[]
             | select(
@@ -94,7 +97,7 @@ fi
 # Check if any pods are pending
 #
 PODS_PENDING=$(
-    kubectl get pods -o json ${ns} \
+    kubectl get pods -o json ${ns} "${psel}" \
         | jq -r '
             .items[]
             | select(.status.phase == "Pending")
@@ -116,7 +119,7 @@ fi
 # Check if any pod has a container with a non-ready status
 #
 PODS_NON_READY=$(
-    kubectl get pods -o json ${ns} \
+    kubectl get pods -o json ${ns} "${psel}" \
         | jq -r '
             .items[]
             | select(


### PR DESCRIPTION
The pod-selector input is applied as `--selector=<pod-selector>` whenever `kubectl get pod` is used.

### Motivation

mybinder.org-deploy has a deployment script that can benefit from this, but currently this action emit info on all pods with trouble (restarts, pending, non-ready) in the namespace. This is too much information and would be a privacy concern for the user pods.

By providing this selector, it can be more feasible to use in such settings.

Fixes #2

### Off topic ideas
- [ ] A selector for all non-pods resources _could be_ relevant.