### PR TITLE
ci: add dependabot for gha, update workflows generally, and use v1,v2,etc tags instead of branches, use pre-commit.ci

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,7 @@
 #
 # Notes:
 # - Status and logs from dependabot are provided at
-#   https://github.com/jupyterhub/action-k3s-helm/network/updates.
+#   https://github.com/jupyterhub/action-k8s-namespace-report/network/updates.
 #
 version: 2
 updates:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/action-k3s-helm/network/updates.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/release-updates.yaml
+++ b/.github/workflows/release-updates.yaml
@@ -15,13 +15,6 @@ jobs:
       contents: write
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
-      # NOTE: We pin a version not to have the source code (.ts files), but the
-      #       compiled source code (.js files). This git hash is what v2.0.1
-      #       referenced 30 December 2020.
       - uses: Actions-R-Us/actions-tagger@95c51c646e75db5c6b7d447e3087bcee58677341
-        env:
-          GITHUB_TOKEN: "${{ github.token }}"
         with:
-          # By using branches as identifiers it is still possible to backtrack
-          # some patch, but not if we use tags.
-          prefer_branch_releases: true
+          token: "${{ github.token }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 # Tests the local GitHub Action.
 #
 # This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 ---
 name: Test
@@ -10,26 +10,24 @@ on:
   pull_request:
   push:
     branches-ignore:
-      - "v*"
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  lint:
-    name: Lint
+  pre-commit:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
 
       # https://github.com/pre-commit/action
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
 
   test:
-    name: Test
     runs-on: ubuntu-20.04
 
     strategy:
@@ -37,23 +35,23 @@ jobs:
       matrix:
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-channel: v1.20
+          - k3s-channel: latest
             test-pods: restarted healthy non-ready pending
             input-namespace: ""
             input-pod-selector: pod-number notin (2,3)
             input-important-workloads: pod/test-healthy-1 pod/test-healthy-2
-          - k3s-channel: v1.20
+          - k3s-channel: stable
             test-pods: ""
             input-namespace: kube-system
             input-important-workloads: ""
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Start a local k8s cluster
       # https://github.com/jupyterhub/action-k3s-helm/
       - name: Setup k8s
-        uses: jupyterhub/action-k3s-helm@v1
+        uses: jupyterhub/action-k3s-helm@v2
         with:
           k3s-channel: ${{ matrix.k3s-channel }}
           metrics-enabled: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,17 +16,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-
-      # https://github.com/pre-commit/action
-      - uses: pre-commit/action@v3.0.0
-
   test:
     runs-on: ubuntu-20.04
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GitHub Action: Emit a k8s namespace report
-[![GitHub Action badge](https://github.com/jupyterhub/action-k8s-namespace-report/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k8s-namespace-report/actions)
+[![GitHub Action badge](https://github.com/jupyterhub/action-k8s-namespace-report/workflows/test/badge.svg)](https://github.com/jupyterhub/action-k8s-namespace-report/actions)
 
 GitHub Action to report info and logs from the current namespace.
 


### PR DESCRIPTION
See https://github.com/jupyterhub/action-k3s-helm/issues/44.

I've removed branche v1 and added tag v1 along with this.